### PR TITLE
메뉴를 더 간단하게 보여주도록 수정함.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ Example
  <Meal: 6 Menus>, <Meal: 6 Menus>, <Meal: Empty>, <Meal: Empty>]
 
 >>> print(meals[1].menus)
-[<Menu: 혼합잡곡밥>, <Menu: 돈육김치찌개>, <Menu: 안동찜닭>,
- <Menu: 콩나물무침>, <Menu: 삼치살양념구이>, <Menu: 석박지>]
+['혼합잡곡밥', '돈육김치찌개', '안동찜닭',
+ '콩나물무침', '삼치살양념구이', '석박지']
 ```
 
 `School.get_weekly_meals()` takes `year`, `month`, `day` and `type` for parameters.

--- a/neis/meal.py
+++ b/neis/meal.py
@@ -14,7 +14,7 @@ class Menu(object):
         return self._allergy
 
     def __repr__(self):
-        ret = '<Menu: {}>'.format(self.text)
+        ret = '\'{}\''.format(self.text)
 
         if sys.version_info.major == 2:
             return ret.encode(sys.stdout.encoding or 'utf-8')


### PR DESCRIPTION
# 개요
급식을 보여주는 전 단계까지 쭉 `<School: >`, `<Meals: >`같은 포멧 스타일을 쓰셨던데 이런 포멧은 실제로 급식을 출력할 때는 순수 메뉴만 보여주기 위한 정규식을 동원하게 되어 매우 불편한 상황입니다.

## 개선 이전
```python
>>> print(meals[1].menus)
[<Menu: 친환경잡곡밥(고)'>, <Menu: 조갯살미역국(고)>, <Menu: 도라지오이생채(고)>,
 <Menu: 닭가슴살커틀렛(고)>, <Menu: 배추김치(제조용)>, <Menu: 양상추샐러드/블루베리소스>]
```

## 개선 이후
```python
>>> print meals[1].menus
['친환경잡곡밥(고)', '조갯살미역국(고)', '도라지오이생채(고)',
 '닭가슴살커틀렛(고)', '배추김치(제조용)', '양상추샐러드/블루베리소스']
```
